### PR TITLE
fix ld64 build using gcc4.3 and gcc4.4

### DIFF
--- a/odcctools-9.2-ld/ld64/src/ld.cpp
+++ b/odcctools-9.2-ld/ld64/src/ld.cpp
@@ -2926,42 +2926,42 @@ ObjectFile::Reader* Linker::createReader(const Options::FileInfo& info)
 	switch (fArchitecture) {
 		case CPU_TYPE_POWERPC:
 			if ( mach_o::relocatable::Reader<ppc>::validFile(p) )
-				return this->addObject(new typename mach_o::relocatable::Reader<ppc>::Reader(p, info.path, info.modTime, fOptions.readerOptions(), fNextInputOrdinal), info, len);
+				return this->addObject(new mach_o::relocatable::Reader<ppc>::Reader(p, info.path, info.modTime, fOptions.readerOptions(), fNextInputOrdinal), info, len);
 			else if ( mach_o::dylib::Reader<ppc>::validFile(p, info.options.fBundleLoader) )
-				return this->addDylib(new typename mach_o::dylib::Reader<ppc>::Reader(p, len, info.path, info.options, fOptions.readerOptions(), fNextInputOrdinal), info, len);
+				return this->addDylib(new mach_o::dylib::Reader<ppc>::Reader(p, len, info.path, info.options, fOptions.readerOptions(), fNextInputOrdinal), info, len);
 			else if ( archive::Reader<ppc>::validFile(p, len) )
-				return this->addArchive(new typename archive::Reader<ppc>::Reader(p, len, info.path, info.modTime, fOptions.readerOptions(), fNextInputOrdinal), info, len);
+				return this->addArchive(new archive::Reader<ppc>::Reader(p, len, info.path, info.modTime, fOptions.readerOptions(), fNextInputOrdinal), info, len);
 			break;
 		case CPU_TYPE_POWERPC64:
 			if ( mach_o::relocatable::Reader<ppc64>::validFile(p) )
-				return this->addObject(new typename mach_o::relocatable::Reader<ppc64>::Reader(p, info.path, info.modTime, fOptions.readerOptions(), fNextInputOrdinal), info, len);
+				return this->addObject(new mach_o::relocatable::Reader<ppc64>::Reader(p, info.path, info.modTime, fOptions.readerOptions(), fNextInputOrdinal), info, len);
 			else if ( mach_o::dylib::Reader<ppc64>::validFile(p, info.options.fBundleLoader) )
-				return this->addDylib(new typename mach_o::dylib::Reader<ppc64>::Reader(p, len, info.path, info.options, fOptions.readerOptions(), fNextInputOrdinal), info, len);
+				return this->addDylib(new mach_o::dylib::Reader<ppc64>::Reader(p, len, info.path, info.options, fOptions.readerOptions(), fNextInputOrdinal), info, len);
 			else if ( archive::Reader<ppc64>::validFile(p, len) )
-				return this->addArchive(new typename archive::Reader<ppc64>::Reader(p, len, info.path, info.modTime, fOptions.readerOptions(), fNextInputOrdinal), info, len);
+				return this->addArchive(new archive::Reader<ppc64>::Reader(p, len, info.path, info.modTime, fOptions.readerOptions(), fNextInputOrdinal), info, len);
 			break;
 		case CPU_TYPE_I386:
 			if ( mach_o::relocatable::Reader<x86>::validFile(p) )
-				return this->addObject(new typename mach_o::relocatable::Reader<x86>::Reader(p, info.path, info.modTime, fOptions.readerOptions(), fNextInputOrdinal), info, len);
+				return this->addObject(new mach_o::relocatable::Reader<x86>::Reader(p, info.path, info.modTime, fOptions.readerOptions(), fNextInputOrdinal), info, len);
 			else if ( mach_o::dylib::Reader<x86>::validFile(p, info.options.fBundleLoader) )
-				return this->addDylib(new typename mach_o::dylib::Reader<x86>::Reader(p, len, info.path, info.options, fOptions.readerOptions(), fNextInputOrdinal), info, len);
+				return this->addDylib(new mach_o::dylib::Reader<x86>::Reader(p, len, info.path, info.options, fOptions.readerOptions(), fNextInputOrdinal), info, len);
 			else if ( archive::Reader<x86>::validFile(p, len) )
-				return this->addArchive(new typename archive::Reader<x86>::Reader(p, len, info.path, info.modTime, fOptions.readerOptions(), fNextInputOrdinal), info, len);
+				return this->addArchive(new archive::Reader<x86>::Reader(p, len, info.path, info.modTime, fOptions.readerOptions(), fNextInputOrdinal), info, len);
 			break;
 		case CPU_TYPE_X86_64:
 			if ( mach_o::relocatable::Reader<x86_64>::validFile(p) )
-				return this->addObject(new typename mach_o::relocatable::Reader<x86_64>::Reader(p, info.path, info.modTime, fOptions.readerOptions(), fNextInputOrdinal), info, len);
+				return this->addObject(new mach_o::relocatable::Reader<x86_64>::Reader(p, info.path, info.modTime, fOptions.readerOptions(), fNextInputOrdinal), info, len);
 			else if ( mach_o::dylib::Reader<x86_64>::validFile(p, info.options.fBundleLoader) )
-				return this->addDylib(new typename mach_o::dylib::Reader<x86_64>::Reader(p, len, info.path, info.options, fOptions.readerOptions(), fNextInputOrdinal), info, len);
+				return this->addDylib(new mach_o::dylib::Reader<x86_64>::Reader(p, len, info.path, info.options, fOptions.readerOptions(), fNextInputOrdinal), info, len);
 			else if ( archive::Reader<x86_64>::validFile(p, len) )
-				return this->addArchive(new typename archive::Reader<x86_64>::Reader(p, len, info.path, info.modTime, fOptions.readerOptions(), fNextInputOrdinal), info, len);
+				return this->addArchive(new archive::Reader<x86_64>::Reader(p, len, info.path, info.modTime, fOptions.readerOptions(), fNextInputOrdinal), info, len);
 		case CPU_TYPE_ARM:
 			if ( mach_o::relocatable::Reader<arm>::validFile(p) )
-				return this->addObject(new typename mach_o::relocatable::Reader<arm>::Reader(p, info.path, info.modTime, fOptions.readerOptions(), fNextInputOrdinal), info, len);
+				return this->addObject(new mach_o::relocatable::Reader<arm>::Reader(p, info.path, info.modTime, fOptions.readerOptions(), fNextInputOrdinal), info, len);
 			else if ( mach_o::dylib::Reader<arm>::validFile(p, info.options.fBundleLoader) )
-				return this->addDylib(new typename mach_o::dylib::Reader<arm>::Reader(p, len, info.path, info.options, fOptions.readerOptions(), fNextInputOrdinal), info, len);
+				return this->addDylib(new mach_o::dylib::Reader<arm>::Reader(p, len, info.path, info.options, fOptions.readerOptions(), fNextInputOrdinal), info, len);
 			else if ( archive::Reader<arm>::validFile(p, len) )
-				return this->addArchive(new typename archive::Reader<arm>::Reader(p, len, info.path, info.modTime, fOptions.readerOptions(), fNextInputOrdinal), info, len);
+				return this->addArchive(new archive::Reader<arm>::Reader(p, len, info.path, info.modTime, fOptions.readerOptions(), fNextInputOrdinal), info, len);
 			break;
 			break;
 	}


### PR DESCRIPTION
ld64 fails building with gcc4.3 or gcc4.4. Here are the errors thrown
by gcc-4.4.7 on my ContOS-6.9:

```
./src/ld.cpp: In member function ‘void Linker::collectStabs(ObjectFile::Reader*, std::map<const ObjectFile::Atom*, unsigned int, std::less<const ObjectFile::Atom*>, std::allocator<std::pair<const ObjectFile::Atom* const, unsigned int> > >&)’:
./src/ld.cpp:2309: warning: format ‘%lu’ expects type ‘long unsigned int’, but argument 3 has type ‘size_t’
./src/ld.cpp: In member function ‘ObjectFile::Reader* Linker::createReader(const Options::FileInfo&)’:
./src/ld.cpp:2929: error: using ‘typename’ outside of template
./src/ld.cpp:2931: error: using ‘typename’ outside of template
./src/ld.cpp:2933: error: using ‘typename’ outside of template
./src/ld.cpp:2937: error: using ‘typename’ outside of template
./src/ld.cpp:2939: error: using ‘typename’ outside of template
./src/ld.cpp:2941: error: using ‘typename’ outside of template
./src/ld.cpp:2945: error: using ‘typename’ outside of template
./src/ld.cpp:2947: error: using ‘typename’ outside of template
./src/ld.cpp:2949: error: using ‘typename’ outside of template
./src/ld.cpp:2953: error: using ‘typename’ outside of template
./src/ld.cpp:2955: error: using ‘typename’ outside of template
./src/ld.cpp:2957: error: using ‘typename’ outside of template
./src/ld.cpp:2960: error: using ‘typename’ outside of template
./src/ld.cpp:2962: error: using ‘typename’ outside of template
./src/ld.cpp:2964: error: using ‘typename’ outside of template
```

This changeset fixes the build.  As far as I can see, one other forker
uses the same fix:
https://github.com/kevinxucs/xchain/commit/0910b5a3635ac16b5c2b23d2f8637ad1e70e8a88

Regards.